### PR TITLE
Missing initscript to make 'make install' work

### DIFF
--- a/voltage_server_startup
+++ b/voltage_server_startup
@@ -1,0 +1,51 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          voltage_server
+# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Stop:     $local_fs $network $named $time $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       Daemon to monitor Intel Edison battery voltage
+### END INIT INFO
+
+SCRIPT=/usr/local/bin/voltage_server
+RUNAS=root
+
+PIDFILE=/var/run/<NAME>.pid
+LOGFILE=/var/log/<NAME>.log
+
+start() {
+  if [ -f /var/run/$PIDNAME ] && kill -0 $(cat /var/run/$PIDNAME); then
+    echo 'Service already running' >&2
+    return 1
+  fi
+  echo 'Starting service…' >&2
+  local CMD="$SCRIPT &> \"$LOGFILE\" & echo \$!"
+  su -c "$CMD" $RUNAS > "$PIDFILE"
+  echo 'Service started' >&2
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE"); then
+    echo 'Service not running' >&2
+    return 1
+  fi
+  echo 'Stopping service…' >&2
+  kill -15 $(cat "$PIDFILE") && rm -f "$PIDFILE"
+  echo 'Service stopped' >&2
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+esac


### PR DESCRIPTION
'make install' expects the existance of a file voltage_server_startup, which should be a LSB-standard SysV init script.

This script does not exist.

Fix:  Created basic LSB initscript, as required by 'make install'.